### PR TITLE
use local flow executable if available

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -21,7 +21,7 @@ module.exports = {
     executablePath: {
       type: 'string',
       description: 'Path to `flow` executable',
-      default: 'flow'
+      default: ''
     }
   },
 
@@ -58,13 +58,23 @@ module.exports = {
           }
         }
 
+        const executable = (
+          this.executablePath ||
+          await findCachedAsync(fileDirectory, 'node_modules/.bin/flow') ||
+          'flow'
+        )
+
         let result
         try {
-          result = await exec(this.executablePath, ['status', '--json'], {cwd: fileDirectory})
-        } catch (_) {
-          if (_.message.indexOf(INIT_MESSAGE) !== -1) {
+          result = await exec(executable, ['status', '--json'], {cwd: fileDirectory})
+        } catch (error) {
+          if (error.message.indexOf(INIT_MESSAGE) !== -1) {
             return await linter.lint(textEditor)
-          } else throw _
+          } else if (err.code === 'ENOENT') {
+            throw new Error('Unable to find `flow` executable.')
+          } else {
+            throw error
+          }
         }
 
         return toLinterMessages(result)

--- a/lib/index.js
+++ b/lib/index.js
@@ -59,8 +59,8 @@ module.exports = {
         }
 
         const executable = (
-          this.executablePath ||
           await findCachedAsync(fileDirectory, 'node_modules/.bin/flow') ||
+          this.executablePath ||
           'flow'
         )
 


### PR DESCRIPTION
I installed flow-ide and got hit with an `ENOENT` error everytime I saved, tracked the error to here, figured I would implement the ability to use the local flow executable and add a more descriptive error message.