### PR TITLE
Feature: Goto Definition

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -35,6 +35,9 @@ module.exports = {
     this.subscriptions.add(atom.config.observe('flow-ide.onlyIfAppropriate', onlyIfAppropriate => {
       this.onlyIfAppropriate = onlyIfAppropriate
     }))
+    this.subscriptions.add(atom.commands.add('atom-text-editor', 'flow-ide:goto-definition', () => {
+      this.gotoDefinition()
+    }))
   },
 
   async getExecutablePath(fileDirectory: string): Promise<string> {
@@ -121,5 +124,23 @@ module.exports = {
       }
     }
     return provider
+  },
+
+  async gotoDefinition() {
+    let editor = atom.workspace.getActiveTextEditor()
+    let bufferPosition = editor.getCursorBufferPosition()
+    let filePath = editor.getPath()
+    let fileDirectory = Path.dirname(filePath)
+    let fileContents = editor.getText()
+    let result = await exec(await this.getExecutablePath(fileDirectory), [
+      'get-def', '--json', filePath, bufferPosition.row + 1, bufferPosition.column + 1], { cwd: fileDirectory, stdin: fileContents })
+    result = JSON.parse(result)
+    if(result.path === '') {
+      return
+    }
+    atom.workspace.open(result.path, {
+      initialLine: result.line - 1,
+      initialColumn: result.start - 1
+    })
   }
 }


### PR DESCRIPTION
Added a Goto Definition command, pretty straight forward! 

- It will silently fail if there isn't a definition found, I can add a notification if you would like, I just assumed it would be overkill.
- I didn't want to take the liberty to add keybinds/menu options in case you didn't want to clutter the plugin, but let me know if you want them amended.
- I tried to keep the coding style similar to what you had, please let me know if you want anything changed.

Thanks!