### PR TITLE
Priorities atom settings over local flow

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -22,9 +22,9 @@ export default {
 
   async getExecutablePath(fileDirectory: string): Promise<string> {
     return (
-      await findCachedAsync(fileDirectory, 'node_modules/.bin/flow') ||
-      this.executablePath ||
-      'flow'
+      await this.executablePath ||
+        findCachedAsync(fileDirectory, 'node_modules/.bin/flow') ||
+        'flow'
     )
   },
 


### PR DESCRIPTION
The current implementation ignores your settings and uses the `bin-flow` binary in `node_modules`, if it is installed. Took me a few days to figure out why atom was using an older version of flow (which was installed by a third party npm package) even if I explicitly told it to use a newer one. 

This solves this problem. Hope that could be of use.

Before

```
$ ps aux | grep -i flow  
                                                                                              
oleander         13845   0,0  0,1  2462912   7732   ??  S    11:28pm   0:00.71 [path]node_modules/flow-bin/flow-osx-v0.34.0/flow
oleander         13844   0,0  0,1 29728960   6132   ??  S    11:28pm   0:00.16 [path]node_modules/flow-bin/flow-osx-v0.34.0/flow
oleander         13843   0,0  0,1 29728960   5960   ??  S    11:28pm   0:00.09 [path]node_modules/flow-bin/flow-osx-v0.34.0/flow
oleander         13842   0,0  1,5 29841436 126696   ??  Ss   11:28pm   0:04.97 [path]node_modules/flow-bin/flow-osx-v0.34.0/flow
```

After

```
$ ps aux | grep -i flow                                                                                                

oleander         20335   0,0  0,2  2461108  16220   ??  S    12:32am   0:00.45 /usr/local/Cellar/flow/0.35.0/bin/flow
oleander         20334   0,0  0,1 29727668   9416   ??  S    12:32am   0:00.05 /usr/local/Cellar/flow/0.35.0/bin/flow
oleander         20333   0,0  0,1 29727668   9412   ??  S    12:32am   0:00.05 /usr/local/Cellar/flow/0.35.0/bin/flow
oleander         20332   0,0  1,5 29826332 127168   ??  Ss   12:32am   0:02.19 /usr/local/Cellar/flow/0.35.0/bin/flow
```