### PR TITLE
Fix reference error

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -105,7 +105,7 @@ export default {
           result = await exec(await this.getExecutablePath(fileDirectory), ['autocomplete', '--json', filePath], { cwd: fileDirectory, stdin: fileContents })
         } catch (error) {
           if (error.message.indexOf(INIT_MESSAGE) !== -1 || error.message.indexOf(RECHECKING_MESSAGE) !== -1) {
-            return await provider.getSuggestions(editor)
+            return await provider.getSuggestions(params)
           }
           throw error
         }


### PR DESCRIPTION
`editor` should be `params` to prevent the error in the print screen. The output shows `console.log("EDITOR", editor)` inserted on line 108.

![skarmavbild 2016-11-21 kl 08 13 20](https://cloud.githubusercontent.com/assets/220827/20474826/ca551eca-afc8-11e6-8f6f-2dbf3653551e.png)
