### PR TITLE
Provide a default flowconfig file for autocompletions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#### 1.1.10
+- Provide a default .flowconfig file if onlyIfAppropriate is enabled and a .flowconfig file is not found already
+
 #### 1.1.9
 
 - Fix autocompletion for properties (#33)

--- a/defaultflowconfig/.flowconfig
+++ b/defaultflowconfig/.flowconfig
@@ -1,0 +1,7 @@
+[ignore]
+
+[include]
+
+[libs]
+
+[options]

--- a/lib/index.js
+++ b/lib/index.js
@@ -87,14 +87,14 @@ export default {
         const fileContents = injectPosition(editor.getText(), editor, bufferPosition)
         let flowOptions = ['autocomplete', '--json', filePath]
 
-        if (this.onlyIfAppropriate) {
-          const configFile = await findCachedAsync(fileDirectory, '.flowconfig')
-          if (!configFile) {
+        const configFile = await findCachedAsync(fileDirectory, '.flowconfig')
+        if (!configFile) {
+          if (this.onlyIfAppropriate) {
             return []
+          } else {
+            const defaultFlowFile = Path.resolve(__dirname, '..', 'defaultflowconfig', '.flowconfig')
+            flowOptions = ['autocomplete', '--root', defaultFlowFile, '--json', filePath]
           }
-        } else {
-          const defaultFlowFile = Path.resolve(__dirname, '..', 'defaultflowconfig', '.flowconfig')
-          flowOptions = ['autocomplete', '--root', defaultFlowFile, '--json', filePath]
         }
 
         // NOTE: Fix for class properties autocompletion

--- a/lib/index.js
+++ b/lib/index.js
@@ -48,6 +48,8 @@ export default {
           if (!configFile) {
             return []
           }
+        } else {
+          return []
         }
 
         const executable = await this.getExecutablePath(fileDirectory)
@@ -80,15 +82,19 @@ export default {
       getSuggestions: async (params) => {
         const { editor, bufferPosition, activatedManually } = params
         let prefix = params.prefix
-        const filePath = editor.getPath()
+        let filePath = editor.getPath()
         const fileDirectory = Path.dirname(filePath)
         const fileContents = injectPosition(editor.getText(), editor, bufferPosition)
+        let flowOptions = ['autocomplete', '--json', filePath]
 
         if (this.onlyIfAppropriate) {
           const configFile = await findCachedAsync(fileDirectory, '.flowconfig')
           if (!configFile) {
             return []
           }
+        } else {
+          const defaultFlowFile = Path.resolve(__dirname, '..', 'defaultflowconfig', '.flowconfig')
+          flowOptions = ['autocomplete', '--root', defaultFlowFile, '--json', filePath]
         }
 
         // NOTE: Fix for class properties autocompletion
@@ -102,7 +108,7 @@ export default {
 
         let result
         try {
-          result = await exec(await this.getExecutablePath(fileDirectory), ['autocomplete', '--json', filePath], { cwd: fileDirectory, stdin: fileContents })
+          result = await exec(await this.getExecutablePath(fileDirectory), flowOptions, { cwd: fileDirectory, stdin: fileContents })
         } catch (error) {
           if (error.message.indexOf(INIT_MESSAGE) !== -1 || error.message.indexOf(RECHECKING_MESSAGE) !== -1) {
             return await provider.getSuggestions(params)


### PR DESCRIPTION
Hi there! I love flow-ide, but I was getting sad while trying to use it while I had it enabled on a bunch of projects that i dont have set up with flow.

I made this change to provide a default flowconfig file for projects that don't have one. This allows some basic autocompletions at least to happen and now it doesn't throw an error also.  This is just a rough idea I through together in a few min because I honestly have no idea what i'm doing with atom plugins... but I've been finding it super helpful on my projects so far