### PR TITLE
add function extend info in autocomplete description

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -67,6 +67,7 @@ export function toAutocompleteSuggestions(contents: string, prefix: string) {
     let text = null
     let snippet = null
     let displayText = null
+    let description = null;
 
     if (isFunction) {
       const functionParams = suggestion.func_details.params
@@ -74,6 +75,12 @@ export function toAutocompleteSuggestions(contents: string, prefix: string) {
       snippet = `${suggestion.name}(${functionParams.map(function(value, i) {
         return `\${${i + 1}:${value.name}}`
       }).join(', ')})$${functionParams.length + 1}`
+
+      const params = functionParams.map(param => param.name + (param.type ? `: ${param.type}`: ''));
+      const match = suggestion.type.match(/\(.*?\) => (.*)/);
+      const returnType = match ? `=> ${match[1]}`: '';
+
+      description = `(${params.join(', ')}) ${returnType}`;
     } else {
       text = suggestion.name
     }
@@ -86,6 +93,7 @@ export function toAutocompleteSuggestions(contents: string, prefix: string) {
       leftLabel: isFunction ? 'function' : getType(suggestion),
       displayText,
       replacementPrefix: prefix,
+      description
     }
   })
   return suggestions.sort(function(a, b) {


### PR DESCRIPTION
Now, function params types and return type will be in description

![ff06fe3518](https://cloud.githubusercontent.com/assets/8408911/24979598/8379fb08-1fdd-11e7-9d8b-61d48c5113b1.jpg)
