### PR TITLE
Move priority from the suggestion to the provider

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -32,19 +32,22 @@ export default {
       this.onlyIfAppropriate = onlyIfAppropriate
     }))
 
-    let priority = atom.config.get('flow-ide.hyperclickPriority')
+    let priority = null
     let restartNotification
     this.subscriptions.add(atom.config.observe('flow-ide.hyperclickPriority', (hyperclickPriority) => {
-      if (hyperclickPriority === priority || restartNotification !== undefined) return
+      if (priority != null) {
+        if (hyperclickPriority !== priority && restartNotification === undefined) {
+          restartNotification = atom.notifications.addSuccess('Restart atom to update flow-ide priority?', {
+            dismissable: true,
+            buttons: [{
+              text: 'Restart',
+              onDidClick: () => atom.restartApplication(),
+            }],
+          })
+          restartNotification.onDidDismiss(() => { restartNotification = undefined })
+        }
+      }
       priority = hyperclickPriority
-      const message = 'Restart atom to update flow-ide priority?'
-      const buttons = []
-      buttons.push({
-        text: 'Restart',
-        onDidClick: () => atom.restartApplication(),
-      })
-      restartNotification = atom.notifications.addSuccess(message, { dismissable: true, buttons })
-      restartNotification.onDidDismiss(() => restartNotification = undefined)
     }))
     this.subscriptions.add(atom.config.observe('flow-ide.showUncovered', (showUncovered) => {
       this.showUncovered = showUncovered

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,8 +31,20 @@ export default {
     this.subscriptions.add(atom.config.observe('flow-ide.onlyIfAppropriate', (onlyIfAppropriate) => {
       this.onlyIfAppropriate = onlyIfAppropriate
     }))
+
+    let priority = atom.config.get('flow-ide.hyperclickPriority')
+    let restartNotification
     this.subscriptions.add(atom.config.observe('flow-ide.hyperclickPriority', (hyperclickPriority) => {
-      this.hyperclickPriority = hyperclickPriority
+      if (hyperclickPriority === priority || restartNotification !== undefined) return
+      priority = hyperclickPriority
+      const message = 'Restart atom to update flow-ide priority?'
+      const buttons = []
+      buttons.push({
+        text: 'Restart',
+        onDidClick: () => atom.restartApplication(),
+      })
+      restartNotification = atom.notifications.addSuccess(message, { dismissable: true, buttons })
+      restartNotification.onDidDismiss(() => restartNotification = undefined)
     }))
     this.subscriptions.add(atom.config.observe('flow-ide.showUncovered', (showUncovered) => {
       this.showUncovered = showUncovered
@@ -252,6 +264,7 @@ export default {
 
   provideHyperclick(): HyperclickProvider {
     const provider = {
+      priority: atom.config.get('flow-ide.hyperclickPriority'),
       grammarScopes: ['source.js', 'source.js.jsx'],
       getSuggestionForWord: async (textEditor: TextEditor, text: string, range: Range): Promise<?HyperclickSuggestion> => {
         const filePath = textEditor.getPath()
@@ -300,7 +313,6 @@ export default {
         }
 
         return {
-          priority: this.hyperclickPriority,
           range,
           callback() {
             atom.workspace.open(jsonResult.path, { searchAllPanes: true }).then((editor) => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -32,11 +32,11 @@ export default {
       this.onlyIfAppropriate = onlyIfAppropriate
     }))
 
-    let priority = null
+    this.hyperclickPriority = null
     let restartNotification
     this.subscriptions.add(atom.config.observe('flow-ide.hyperclickPriority', (hyperclickPriority) => {
-      if (priority != null) {
-        if (hyperclickPriority !== priority && restartNotification === undefined) {
+      if (this.hyperclickPriority != null) {
+        if (hyperclickPriority !== this.hyperclickPriority && restartNotification === undefined) {
           restartNotification = atom.notifications.addSuccess('Restart atom to update flow-ide priority?', {
             dismissable: true,
             buttons: [{
@@ -47,7 +47,7 @@ export default {
           restartNotification.onDidDismiss(() => { restartNotification = undefined })
         }
       }
-      priority = hyperclickPriority
+      this.hyperclickPriority = hyperclickPriority
     }))
     this.subscriptions.add(atom.config.observe('flow-ide.showUncovered', (showUncovered) => {
       this.showUncovered = showUncovered
@@ -267,7 +267,7 @@ export default {
 
   provideHyperclick(): HyperclickProvider {
     const provider = {
-      priority: atom.config.get('flow-ide.hyperclickPriority'),
+      priority: this.hyperclickPriority,
       grammarScopes: ['source.js', 'source.js.jsx'],
       getSuggestionForWord: async (textEditor: TextEditor, text: string, range: Range): Promise<?HyperclickSuggestion> => {
         const filePath = textEditor.getPath()

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
       "default": ""
     },
     "hyperclickPriority": {
-      "description": "Priority to use for hyperclick provider",
+      "description": "Priority to use for hyperclick provider (requires restart)",
       "type": "integer",
       "default": "0"
     }


### PR DESCRIPTION
[`HyperclickSuggestion`](https://github.com/facebook/nuclide/blob/35034d564c629e182ff920a6970660a27ef904d3/modules/atom-ide-ui/pkg/hyperclick/lib/types.js#L41-L49) doesn't have a priority. I looked into it, and priority is only read in [`addProvider`](https://github.com/facebook/nuclide/blob/master/modules/nuclide-commons-atom/ProviderRegistry.js#L29), so it looks like it requires a restart to change.