### PR TITLE
Fix edge case when using hyperclick at the end of a word

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -75,6 +75,26 @@ export function injectPosition(text: string, editor: Object, bufferPosition: Obj
   return text.slice(0, characterIndex) + 'AUTO332' + text.slice(characterIndex)
 }
 
+export function adjustPosition (pos: Range, editor: TextEditor) {
+  // Flow fails to determine the position if the cursor is at the end of a word
+  // e.g. "path.dirname ()"
+  //                   ↑ the cursor is here, between "dirname" and "("
+  // In order to avoid this problem we have to check whether the char
+  // at the given position is considered a part of an identifier.
+  // If not step back 1 char as it might contain a valid identifier.
+  const char = editor.getTextInBufferRange([
+    pos,
+    pos.translate([0, 1]),
+  ])
+  const nonWordChars = editor.getNonWordCharacters(
+    editor.scopeDescriptorForBufferPosition(pos),
+  )
+  if (nonWordChars.indexOf(char) >= 0 || /\s/.test(char)) {
+    return pos.translate([0, -1])
+  }
+  return pos
+}
+
 export function toAutocompleteSuggestions(contents: string, prefix: string) {
   if (contents.slice(0, 1) !== '{') {
     // Invalid server response

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,6 +11,7 @@ import {
   INIT_MESSAGE,
   RECHECKING_MESSAGE,
   injectPosition,
+  adjustPosition,
   toStatusLinterMessages,
   toCoverageLinterMessages,
   toAutocompleteSuggestions,
@@ -295,12 +296,13 @@ export default {
           return null
         }
 
+        const pos = adjustPosition(range.start, textEditor)
         const flowOptions = [
           'get-def',
           '--json',
           '--path=' + filePath,
-          range.start.row + 1,
-          range.start.column + 1,
+          pos.row + 1,
+          pos.column + 1,
         ]
 
         let result


### PR DESCRIPTION
As described in the code itself:

Flow fails to determine the position if the cursor is at the end of a word e.g.
```js
path.dirname ()
            ↑ the cursor is here, between "dirname" and "("
```
