### PR TITLE
Fix outline when destructuring

### DIFF
--- a/lib/outline/parse.js
+++ b/lib/outline/parse.js
@@ -66,9 +66,7 @@ function declarationReducer(
       break
     case 'ObjectPattern':
       textElements.push(Text.plain('{'))
-      textElements.push(
-        ...declarationsTokenizedText(options, p.properties.map(obj => obj.key)),
-      )
+      textElements.push(...declarationsTokenizedText(options, p.properties))
       textElements.push(Text.plain('}'))
       break
     case 'ArrayPattern':
@@ -79,6 +77,7 @@ function declarationReducer(
     case 'AssignmentPattern':
       return declarationReducer(options, textElements, p.left, index, declarations)
     case 'RestElement':
+    case 'RestProperty':
       textElements.push(Text.plain('...'))
       return declarationReducer(options, textElements, p.argument, index, declarations)
     default:

--- a/lib/outline/parse.js
+++ b/lib/outline/parse.js
@@ -47,47 +47,54 @@ function exportDeclaration(
 }
 
 function declarationsTokenizedText(options: OutlineOptions, declarations: Array<Object>): TokenizedText {
-  return declarations.reduce((els, dec, i, decs) =>
-    declarationReducer(options, els, dec, i, decs), // eslint-disable-line
-    [],
-  )
+  return declarations.reduce((text, decl, i, decls) => {
+    text.push(...declarationReducer(options, decl)) // eslint-disable-line
+    if (i < decls.length - 1) {
+      text.push(Text.plain(','))
+      text.push(Text.whitespace(' '))
+    }
+    return text
+  }, [])
 }
 
 function declarationReducer(
   options: OutlineOptions,
-  textElements: TokenizedText,
-  p: Object,
-  index: number,
-  declarations: Array<Object>,
+  decl: Object,
 ): TokenizedText {
-  switch (p.type) {
+  if (!decl) {
+    // special case: array patterns can contain `null` elements
+    // which means that this value is simply ignored.
+    return []
+  }
+
+  switch (decl.type) {
     case 'Identifier':
-      textElements.push(Text.param(p.name))
-      break
+      return [Text.param(decl.name)]
     case 'ObjectPattern':
-      textElements.push(Text.plain('{'))
-      textElements.push(...declarationsTokenizedText(options, p.properties))
-      textElements.push(Text.plain('}'))
-      break
+      return [
+        Text.plain('{'),
+        ...declarationsTokenizedText(options, decl.properties),
+        Text.plain('}'),
+      ]
     case 'ArrayPattern':
-      textElements.push(Text.plain('['))
-      textElements.push(...declarationsTokenizedText(options, p.elements))
-      textElements.push(Text.plain(']'))
-      break
+      return [
+        Text.plain('['),
+        ...declarationsTokenizedText(options, decl.elements),
+        Text.plain(']'),
+      ]
     case 'AssignmentPattern':
-      return declarationReducer(options, textElements, p.left, index, declarations)
+      return declarationReducer(options, decl.left)
     case 'RestElement':
     case 'RestProperty':
-      textElements.push(Text.plain('...'))
-      return declarationReducer(options, textElements, p.argument, index, declarations)
+      return [
+        Text.plain('...'),
+        ...declarationReducer(options, decl.argument),
+      ]
+    case 'Property':
+      return declarationReducer(options, decl.value)
     default:
-      throw new Error(`encountered unexpected argument type ${p.type}`)
+      throw new Error(`encountered unexpected argument type ${decl.type}`)
   }
-  if (index < declarations.length - 1) {
-    textElements.push(Text.plain(','))
-    textElements.push(Text.whitespace(' '))
-  }
-  return textElements
 }
 
 function getExtent(item: Object): Extent {

--- a/spec/outline/parse-sample-ast.js
+++ b/spec/outline/parse-sample-ast.js
@@ -874,14 +874,12 @@ export const exportedFuncWithObjectRest = {
               loc: loc(lc(1, 13), lc(1, 23)),
               range: [13, 23],
               name: 'restSpread',
-              typeAnnotation: null,
               optional: false,
             },
             init: {
               type: 'ArrowFunctionExpression',
               loc: loc(lc(1, 26), lc(1, 52)),
               range: [26, 52],
-              id: null,
               params: [
                 {
                   type: 'AssignmentPattern',
@@ -901,12 +899,10 @@ export const exportedFuncWithObjectRest = {
                           loc: loc(lc(1, 32), lc(1, 36)),
                           range: [32, 36],
                           name: 'rest',
-                          typeAnnotation: null,
                           optional: false,
                         },
                       },
                     ],
-                    typeAnnotation: null,
                   },
                   right: {
                     type: 'ObjectExpression',
@@ -921,15 +917,11 @@ export const exportedFuncWithObjectRest = {
                 loc: loc(lc(1, 48), lc(1, 52)),
                 range: [48, 52],
                 name: 'rest',
-                typeAnnotation: null,
                 optional: false,
               },
               async: false,
               generator: false,
-              predicate: null,
               expression: true,
-              returnType: null,
-              typeParameters: null,
             },
           },
         ],
@@ -937,6 +929,167 @@ export const exportedFuncWithObjectRest = {
       },
       specifiers: [],
       exportKind: 'value',
+    },
+  ],
+  comments: [],
+}
+
+/*
+const { first, second: renamed, ...rest } = {}
+ */
+export const objectDestructuring = {
+  errors: [],
+  tokens: [],
+  type: 'Program',
+  loc: loc(lc(1, 0), lc(1, 46)),
+  range: [0, 46],
+  body: [
+    {
+      type: 'VariableDeclaration',
+      loc: loc(lc(1, 0), lc(1, 46)),
+      range: [0, 46],
+      declarations: [
+        {
+          type: 'VariableDeclarator',
+          loc: loc(lc(1, 6), lc(1, 46)),
+          range: [6, 46],
+          id: {
+            type: 'ObjectPattern',
+            loc: loc(lc(1, 6), lc(1, 41)),
+            range: [6, 41],
+            properties: [
+              {
+                type: 'Property',
+                loc: loc(lc(1, 8), lc(1, 13)),
+                range: [8, 13],
+                key: {
+                  type: 'Identifier',
+                  loc: loc(lc(1, 8), lc(1, 13)),
+                  range: [8, 13],
+                  name: 'first',
+                  optional: false,
+                },
+                value: {
+                  type: 'Identifier',
+                  loc: loc(lc(1, 8), lc(1, 13)),
+                  range: [8, 13],
+                  name: 'first',
+                  optional: false,
+                },
+                kind: 'init',
+                method: false,
+                shorthand: true,
+                computed: false,
+              },
+              {
+                type: 'Property',
+                loc: loc(lc(1, 15), lc(1, 30)),
+                range: [15, 30],
+                key: {
+                  type: 'Identifier',
+                  loc: loc(lc(1, 15), lc(1, 21)),
+                  range: [15, 21],
+                  name: 'second',
+                  optional: false,
+                },
+                value: {
+                  type: 'Identifier',
+                  loc: loc(lc(1, 23), lc(1, 30)),
+                  range: [23, 30],
+                  name: 'renamed',
+                  optional: false,
+                },
+                kind: 'init',
+                method: false,
+                shorthand: false,
+                computed: false,
+              },
+              {
+                type: 'RestProperty',
+                loc: loc(lc(1, 32), lc(1, 39)),
+                range: [32, 39],
+                argument: {
+                  type: 'Identifier',
+                  loc: loc(lc(1, 35), lc(1, 39)),
+                  range: [35, 39],
+                  name: 'rest',
+                  optional: false,
+                },
+              },
+            ],
+          },
+          init: {
+            type: 'ObjectExpression',
+            loc: loc(lc(1, 44), lc(1, 46)),
+            range: [44, 46],
+            properties: [],
+          },
+        },
+      ],
+      kind: 'const',
+    },
+  ],
+  comments: [],
+}
+
+/*
+const [first, , ...rest] = []
+ */
+export const arrayDestructuring = {
+  errors: [],
+  tokens: [],
+  type: 'Program',
+  loc: loc(lc(1, 0), lc(1, 29)),
+  range: [0, 29],
+  body: [
+    {
+      type: 'VariableDeclaration',
+      loc: loc(lc(1, 0), lc(1, 29)),
+      range: [0, 29],
+      declarations: [
+        {
+          type: 'VariableDeclarator',
+          loc: loc(lc(1, 6), lc(1, 29)),
+          range: [6, 29],
+          id: {
+            type: 'ArrayPattern',
+            loc: loc(lc(1, 6), lc(1, 24)),
+            range: [6, 24],
+            elements: [
+              {
+                type: 'Identifier',
+                loc: loc(lc(1, 7), lc(1, 12)),
+                range: [7, 12],
+                name: 'first',
+                typeAnnotation: null,
+                optional: false,
+              },
+              null,
+              {
+                type: 'RestElement',
+                loc: loc(lc(1, 16), lc(1, 23)),
+                range: [16, 23],
+                argument: {
+                  type: 'Identifier',
+                  loc: loc(lc(1, 19), lc(1, 23)),
+                  range: [19, 23],
+                  name: 'rest',
+                  typeAnnotation: null,
+                  optional: false,
+                },
+              },
+            ],
+            typeAnnotation: null,
+          },
+          init: {
+            type: 'ArrayExpression',
+            loc: loc(lc(1, 27), lc(1, 29)),
+            range: [27, 29],
+            elements: [],
+          },
+        },
+      ],
+      kind: 'const',
     },
   ],
   comments: [],

--- a/spec/outline/parse-sample-ast.js
+++ b/spec/outline/parse-sample-ast.js
@@ -845,3 +845,99 @@ export const exportedClassDecl = {
     exportKind: 'value',
   }],
 }
+
+/*
+export const restSpread = ({ ...rest }) => rest
+ */
+export const exportedFuncWithObjectRest = {
+  errors: [],
+  tokens: [],
+  type: 'Program',
+  loc: loc(lc(1, 0), lc(1, 52)),
+  range: [0, 52],
+  body: [
+    {
+      type: 'ExportNamedDeclaration',
+      loc: loc(lc(1, 0), lc(1, 52)),
+      range: [0, 52],
+      declaration: {
+        type: 'VariableDeclaration',
+        loc: loc(lc(1, 7), lc(1, 52)),
+        range: [7, 52],
+        declarations: [
+          {
+            type: 'VariableDeclarator',
+            loc: loc(lc(1, 13), lc(1, 52)),
+            range: [13, 52],
+            id: {
+              type: 'Identifier',
+              loc: loc(lc(1, 13), lc(1, 23)),
+              range: [13, 23],
+              name: 'restSpread',
+              typeAnnotation: null,
+              optional: false,
+            },
+            init: {
+              type: 'ArrowFunctionExpression',
+              loc: loc(lc(1, 26), lc(1, 52)),
+              range: [26, 52],
+              id: null,
+              params: [
+                {
+                  type: 'AssignmentPattern',
+                  loc: loc(lc(1, 27), lc(1, 43)),
+                  range: [27, 43],
+                  left: {
+                    type: 'ObjectPattern',
+                    loc: loc(lc(1, 27), lc(1, 38)),
+                    range: [27, 38],
+                    properties: [
+                      {
+                        type: 'RestProperty',
+                        loc: loc(lc(1, 29), lc(1, 36)),
+                        range: [29, 36],
+                        argument: {
+                          type: 'Identifier',
+                          loc: loc(lc(1, 32), lc(1, 36)),
+                          range: [32, 36],
+                          name: 'rest',
+                          typeAnnotation: null,
+                          optional: false,
+                        },
+                      },
+                    ],
+                    typeAnnotation: null,
+                  },
+                  right: {
+                    type: 'ObjectExpression',
+                    loc: loc(lc(1, 41), lc(1, 43)),
+                    range: [41, 43],
+                    properties: [],
+                  },
+                },
+              ],
+              body: {
+                type: 'Identifier',
+                loc: loc(lc(1, 48), lc(1, 52)),
+                range: [48, 52],
+                name: 'rest',
+                typeAnnotation: null,
+                optional: false,
+              },
+              async: false,
+              generator: false,
+              predicate: null,
+              expression: true,
+              returnType: null,
+              typeParameters: null,
+            },
+          },
+        ],
+        kind: 'const',
+      },
+      specifiers: [],
+      exportKind: 'value',
+    },
+  ],
+  comments: [],
+}

--- a/spec/outline/parse-spec.js
+++ b/spec/outline/parse-spec.js
@@ -6,6 +6,7 @@ import {
   func, exportedFunc,
   variables, exportedVariables,
   classDecl, exportedClassDecl,
+  exportedFuncWithObjectRest,
 } from './parse-sample-ast'
 import * as Parse from '../../lib/outline/parse'
 
@@ -187,6 +188,29 @@ describe('outline/parse', function() {
         Parse.astToOutline(buildOptions(true, true), exportedVariables).outlineTrees,
       )).toEqual(
         ['export exportedConstantValue', 'export exportedLetValue', 'export exportedVarValue'],
+      )
+    })
+
+    it('exported func with object rest', function() {
+      expect(toOutlineTexts(
+        Parse.astToOutline(buildOptions(false, false), exportedFuncWithObjectRest).outlineTrees,
+      )).toEqual(
+        ['restSpread'],
+      )
+      expect(toOutlineTexts(
+        Parse.astToOutline(buildOptions(true, false), exportedFuncWithObjectRest).outlineTrees,
+      )).toEqual(
+        ['export restSpread'],
+      )
+      expect(toOutlineTexts(
+        Parse.astToOutline(buildOptions(false, true), exportedFuncWithObjectRest).outlineTrees,
+      )).toEqual(
+        ['restSpread({...rest})'],
+      )
+      expect(toOutlineTexts(
+        Parse.astToOutline(buildOptions(true, true), exportedFuncWithObjectRest).outlineTrees,
+      )).toEqual(
+        ['export restSpread({...rest})'],
       )
     })
   })

--- a/spec/outline/parse-spec.js
+++ b/spec/outline/parse-spec.js
@@ -6,6 +6,7 @@ import {
   func, exportedFunc,
   variables, exportedVariables,
   classDecl, exportedClassDecl,
+  objectDestructuring, arrayDestructuring,
   exportedFuncWithObjectRest,
 } from './parse-sample-ast'
 import * as Parse from '../../lib/outline/parse'
@@ -188,6 +189,52 @@ describe('outline/parse', function() {
         Parse.astToOutline(buildOptions(true, true), exportedVariables).outlineTrees,
       )).toEqual(
         ['export exportedConstantValue', 'export exportedLetValue', 'export exportedVarValue'],
+      )
+    })
+
+    it('object destructuring', function() {
+      expect(toOutlineTexts(
+        Parse.astToOutline(buildOptions(false, false), objectDestructuring).outlineTrees,
+      )).toEqual(
+        ['{first, renamed, ...rest}'],
+      )
+      expect(toOutlineTexts(
+        Parse.astToOutline(buildOptions(true, false), objectDestructuring).outlineTrees,
+      )).toEqual(
+        ['{first, renamed, ...rest}'],
+      )
+      expect(toOutlineTexts(
+        Parse.astToOutline(buildOptions(false, true), objectDestructuring).outlineTrees,
+      )).toEqual(
+        ['{first, renamed, ...rest}'],
+      )
+      expect(toOutlineTexts(
+        Parse.astToOutline(buildOptions(true, true), objectDestructuring).outlineTrees,
+      )).toEqual(
+        ['{first, renamed, ...rest}'],
+      )
+    })
+
+    it('array destructuring', function() {
+      expect(toOutlineTexts(
+        Parse.astToOutline(buildOptions(false, false), arrayDestructuring).outlineTrees,
+      )).toEqual(
+        ['[first, , ...rest]'],
+      )
+      expect(toOutlineTexts(
+        Parse.astToOutline(buildOptions(true, false), arrayDestructuring).outlineTrees,
+      )).toEqual(
+        ['[first, , ...rest]'],
+      )
+      expect(toOutlineTexts(
+        Parse.astToOutline(buildOptions(false, true), arrayDestructuring).outlineTrees,
+      )).toEqual(
+        ['[first, , ...rest]'],
+      )
+      expect(toOutlineTexts(
+        Parse.astToOutline(buildOptions(true, true), arrayDestructuring).outlineTrees,
+      )).toEqual(
+        ['[first, , ...rest]'],
       )
     })
 


### PR DESCRIPTION
Minimal reproducible code samples that caused exceptions:

```js
export const restSpread = ({ ...rest }) => rest
```

```js
const { first, second: renamed, ...rest } = {}
```

```js
const [first, , ...rest] = []
```