### PR TITLE
Add tree-sitter grammar for javascript to grammar scopes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -31,7 +31,7 @@ const servers: Map<string, Server> = new Map()
 
 const defaultFlowFile = Path.resolve(__dirname, '..', 'vendor', '.flowconfig')
 const defaultFlowBinLocation = 'node_modules/.bin/flow'
-const grammarScopes = ['source.js', 'source.js.jsx']
+const grammarScopes = ['source.js', 'source.js.jsx', 'flow-javascript']
 
 function handleError(error: { message: string, code: string }, configFile: ?string) {
   if (error.message.indexOf(INIT_MESSAGE) !== -1 && typeof configFile === 'string') {


### PR DESCRIPTION
I use atom-nightly and have been using the experimental tree-sitter parsing. A result of this is that the grammar for javascript files is now 'flow-javascript' and the scope 'source.js' no longer applies.

I've been using this forked version for over a week with no issues. 