### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Flow-IDE
 =======
 
-Flow IDE is a lightweight package that provides IDE features for [FlowType][FlowType] for [Atom Editor][Atom]. It's pretty lightweight and robust.
+Flow IDE is a lightweight package that provides IDE features for [FlowType][FlowType] for [Atom Editor][Atom], based on the [linter][linter] package. It's pretty lightweight and robust.
 
 #### Installation
 ```
@@ -46,5 +46,6 @@ This project is licensed under the terms of MIT License. Check the LICENSE file 
 [hyperclick]:https://github.com/facebook-atom/hyperclick
 [atom-ide-ui]:https://github.com/facebook-atom/atom-ide-ui
 [ide-flow]:https://github.com/lukehoban/atom-ide-flow
+[linter]:https://github.com/steelbrain/linter
 [linter-flow]:https://github.com/AtomLinter/linter-flow
 [autocomplete-flow]:https://github.com/nmn/autocomplete-flow


### PR DESCRIPTION
As it is, it's unclear whether `flow-ide` is based on `atom-ide` or `linter`. This is especially confusing because there's *also* a `ide-flow` package with no dependency, and a `ide-flowtype` package based on `atom-ide`.