### PR TITLE
do not add dots to autocomplete scopes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -280,7 +280,7 @@ export default {
 
   provideAutocomplete(): Object {
     const provider = {
-      selector: grammarScopes.map(item => `.${item}`).join(', '),
+      selector: grammarScopes.map(x => (x.includes('.') ? `.${x}` : x)).join(', '),
       disableForSelector: '.comment',
       inclusionPriority: 100,
       // eslint-disable-next-line arrow-parens


### PR DESCRIPTION
For some reason the scopes do not work anymore if they contain dots (are class names)