### PR TITLE
add `source.flow` grammar scope

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -31,7 +31,7 @@ const servers: Map<string, Server> = new Map()
 
 const defaultFlowFile = Path.resolve(__dirname, '..', 'vendor', '.flowconfig')
 const defaultFlowBinLocation = 'node_modules/.bin/flow'
-const grammarScopes = ['source.js', 'source.js.jsx', 'flow-javascript']
+const grammarScopes = ['source.js', 'source.js.jsx', 'source.flow', 'flow-javascript']
 
 function handleError(error: { message: string, code: string }, configFile: ?string) {
   if (error.message.indexOf(INIT_MESSAGE) !== -1 && typeof configFile === 'string') {


### PR DESCRIPTION
This fixes this package with the newest tree-sitter parser stuff.

The grammar didn't match what the PR at #140 had it set to any more for some reason, and now it's `source.flow` for flow javascript files.

I didn't remove the old flow grammar, just in case it's still that on some machines.