### PR TITLE
make sure "func_details" is not undefined

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -351,7 +351,7 @@ export class Flow {
     const parsed = JSON.parse(contents)
     const hasPrefix = prefix.trim().length
     const suggestions = parsed.result.map((suggestion) => {
-      const isFunction = suggestion.func_details !== null
+      const isFunction = suggestion.func_details !== null && suggestion.func_details !== undefined
       let text = null
       let snippet = null
       let displayText = null


### PR DESCRIPTION
`atom v1.45.0`
`flow-ide v1.13.0`
`flow-bin v0.123.0`

I've started getting autocomplete issues recently. I'm not sure what exactly is causing it, but I'm seeing the following errors in the console whenever I type in Atom:

<img width="1072" alt="Screen Shot 2020-04-27 at 6 39 54 PM" src="https://user-images.githubusercontent.com/440299/80437469-82e9b080-88b6-11ea-9757-07e5cc63e0f9.png">

While debugging this, I noticed `func_details` is not a property on the `suggestion` object here:

https://github.com/steelbrain/flow-ide/blob/master/lib/index.js#L361

With this PR, I'm adding a check for `undefined` to take care of this edge case. I've only tested this locally to confirm the above `TypeError: Cannot read property 'params' of undefined` is no longer an issue. Everything else seems to be working normally, however, I haven't done any other testing.